### PR TITLE
ci: explicit setup-node so .nvmrc
  actually pins Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install, build, and upload
-        uses: withastro/action@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
   deploy:
     needs: build


### PR DESCRIPTION
withastro/action@v3 ignores .nvmrc and only
  honors its node-version input, so the build kept running on Node 20. Switching
  to explicit actions/setup-node@v4 with node-version-file: .nvmrc.